### PR TITLE
Prettierの導入 #3

### DIFF
--- a/articlear/.prettierrc.json
+++ b/articlear/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": false,
+    "singleQuote": true
+}

--- a/articlear/package-lock.json
+++ b/articlear/package-lock.json
@@ -18,6 +18,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "prettier": "2.8.6",
         "tailwindcss": "^3.2.7"
       }
     },
@@ -15597,6 +15598,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.6.tgz",
+      "integrity": "sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -30012,6 +30028,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.6.tgz",
+      "integrity": "sha512-mtuzdiBbHwPEgl7NxWlqOkithPyp4VN93V7VeHVWBF+ad3I5avc0RVDT4oImXQy9H/AqxA2NSQH8pSxHW6FYbQ==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/articlear/package.json
+++ b/articlear/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "devDependencies": {
+    "prettier": "2.8.6",
     "tailwindcss": "^3.2.7"
   }
 }


### PR DESCRIPTION
https://dev.classmethod.jp/articles/introduce-prettier/
https://prettier.io/docs/en/install.html
上記サイトに従ってPrettierを導入しました。

```
npm install --save-dev --save-exact prettier
```
でprettierをインストールし、 https://prettier.io/docs/en/configuration.html に従って以下の設定を追加しました。

```
{
  "trailingComma": "es5",
  "tabWidth": 4,
  "semi": false,
  "singleQuote": true
}
```